### PR TITLE
No need to evaluate a variable two times.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,14 +8,14 @@
                        ansible_local.core.keyserver)
                    else "hkp://pool.sks-keyservers.net" }}'
     state: 'present'
-  when: docker_upstream|d() and docker_upstream
+  when: docker_upstream|d() | bool
 
 - name: Configure upstream APT repository
   apt_repository:
     repo: '{{ docker_upstream_repository }}'
     state: 'present'
     update_cache: True
-  when: docker_upstream|d() and docker_upstream
+  when: docker_upstream|d() | bool
 
 - name: Install required packages
   apt:
@@ -31,7 +31,7 @@
   pip:
     name: 'ferment'
     state: 'present'
-  when: docker_ferment|d() and docker_ferment
+  when: docker_ferment|d() | bool
 
 - name: Install ferment wrapper script
   template:
@@ -40,7 +40,7 @@
     owner: 'root'
     group: 'root'
     mode: '0755'
-  when: docker_ferment|d() and docker_ferment
+  when: docker_ferment|d() | bool
 
 - name: Check Docker version
   environment:
@@ -70,7 +70,7 @@
     mode: '0644'
   notify: [ 'Restart docker' ]
   register: docker_register_systemd_service
-  when: docker_upstream|d() and docker_upstream
+  when: docker_upstream|d() | bool
   tags: [ 'role::docker:config' ]
 
 - name: Reload systemd daemons
@@ -87,6 +87,6 @@
     groups: 'docker'
     append: True
   with_items: docker_admins
-  when: item|d() and item
+  when: item|d()
   tags: [ 'role::docker:config', 'role::docker:admins' ]
 

--- a/templates/etc/default/docker.j2
+++ b/templates/etc/default/docker.j2
@@ -6,41 +6,41 @@
 #DOCKER="/usr/local/bin/docker"
 
 {% set docker_tpl_options = [] %}
-{% if docker_bridge|d() and docker_bridge %}
+{% if docker_bridge|d() | bool %}
 {%   set _ = docker_tpl_options.append("--bridge " + docker_bridge) %}
 {% endif %}
-{% if docker_fixed_cidr|d() and docker_fixed_cidr %}
+{% if docker_fixed_cidr|d() | bool %}
 {%   set _ = docker_tpl_options.append("--fixed-cidr " + docker_fixed_cidr) %}
 {% endif %}
-{% if docker_dns_nameserver|d() and docker_dns_nameserver %}
+{% if docker_dns_nameserver|d() | bool %}
 {%   for nameserver in docker_dns_nameserver %}
 {%     set _ = docker_tpl_options.append("--dns " + nameserver) %}
 {%   endfor %}
 {% endif %}
-{% if docker_dns_search|d() and docker_dns_search %}
+{% if docker_dns_search|d() | bool %}
 {%   for domain in docker_dns_search %}
 {%     set _ = docker_tpl_options.append("--dns-search " + domain) %}
 {%   endfor %}
 {% endif %}
-{% if docker_listen|d() and docker_listen %}
+{% if docker_listen|d() | bool %}
 {%   for host in docker_listen %}
 {%     if host %}
 {%       set _ = docker_tpl_options.append("-H " + host) %}
 {%     endif %}
 {%   endfor %}
 {% endif %}
-{% if docker_pki|d() and docker_pki | bool %}
+{% if docker_pki|d() | bool %}
 {%   set _ = docker_tpl_options.append("--tlsverify") %}
 {%   set _ = docker_tpl_options.append("--tlscacert " + docker_pki_path + "/" + docker_pki_realm + "/" + docker_pki_ca) %}
 {%   set _ = docker_tpl_options.append("--tlscert " + docker_pki_path + "/" + docker_pki_realm + "/" + docker_pki_crt) %}
 {%   set _ = docker_tpl_options.append("--tlskey " + docker_pki_path + "/" + docker_pki_realm + "/" + docker_pki_key) %}
 {% endif %}
-{% if docker_labels|d() and docker_labels %}
+{% if docker_labels|d() | bool %}
 {%   for key, value in docker_labels.iteritems() %}
 {%     set _ = docker_tpl_options.append("--label " + key + '="' + value + '"') %}
 {%   endfor %}
 {% endif %}
-{% if docker_options|d() and docker_options %}
+{% if docker_options|d() | bool %}
 {%   for option in docker_options %}
 {%     if option %}
 {%       set _ = docker_tpl_options.append(option) %}


### PR DESCRIPTION
Example: `docker_upstream|d() and docker_upstream`
- When `docker_upstream` is undefined it defaults to false using the
  Jinja `default` filter. The same applies when `docker_upstream` is False.
- When `docker_upstream` is True, it it tested two times for True.
- Additionally this change now correctly handles:
  
  ``` YAML
  false_var: False
  docker_upstream: '{{ false_var }}'
  ```
