### PR TITLE
tasks: Install pip just to be sure

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,6 +27,12 @@
     - docker_base_packages
     - docker_packages
 
+- name: Install pip
+  apt:
+    name: python-pip
+    state: 'present'
+    install_recommends: False
+
 - name: Install ferment generator
   pip:
     name: 'ferment'


### PR DESCRIPTION
It is needed for the ferment generator.
If this role is being used in a standalone mode,
then pip has not necessarily been installed.
