### PR TITLE
"Bool" filter should be used only for boolean variables

### DIFF
--- a/templates/etc/default/docker.j2
+++ b/templates/etc/default/docker.j2
@@ -6,23 +6,23 @@
 #DOCKER="/usr/local/bin/docker"
 
 {% set docker_tpl_options = [] %}
-{% if docker_bridge|d() | bool %}
+{% if docker_bridge|d() %}
 {%   set _ = docker_tpl_options.append("--bridge " + docker_bridge) %}
 {% endif %}
-{% if docker_fixed_cidr|d() | bool %}
+{% if docker_fixed_cidr|d() %}
 {%   set _ = docker_tpl_options.append("--fixed-cidr " + docker_fixed_cidr) %}
 {% endif %}
-{% if docker_dns_nameserver|d() | bool %}
+{% if docker_dns_nameserver|d() %}
 {%   for nameserver in docker_dns_nameserver %}
 {%     set _ = docker_tpl_options.append("--dns " + nameserver) %}
 {%   endfor %}
 {% endif %}
-{% if docker_dns_search|d() | bool %}
+{% if docker_dns_search|d() %}
 {%   for domain in docker_dns_search %}
 {%     set _ = docker_tpl_options.append("--dns-search " + domain) %}
 {%   endfor %}
 {% endif %}
-{% if docker_listen|d() | bool %}
+{% if docker_listen|d() %}
 {%   for host in docker_listen %}
 {%     if host %}
 {%       set _ = docker_tpl_options.append("-H " + host) %}
@@ -35,12 +35,12 @@
 {%   set _ = docker_tpl_options.append("--tlscert " + docker_pki_path + "/" + docker_pki_realm + "/" + docker_pki_crt) %}
 {%   set _ = docker_tpl_options.append("--tlskey " + docker_pki_path + "/" + docker_pki_realm + "/" + docker_pki_key) %}
 {% endif %}
-{% if docker_labels|d() | bool %}
+{% if docker_labels|d() %}
 {%   for key, value in docker_labels.iteritems() %}
 {%     set _ = docker_tpl_options.append("--label " + key + '="' + value + '"') %}
 {%   endfor %}
 {% endif %}
-{% if docker_options|d() | bool %}
+{% if docker_options|d() %}
 {%   for option in docker_options %}
 {%     if option %}
 {%       set _ = docker_tpl_options.append(option) %}


### PR DESCRIPTION
This closes #2 bug introduced by 427f7d7e5a870b4db403864951948c3fa67cd92f.
