### PR TITLE
Add 'setuptools' as dependency for 'ferment'

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,7 +46,7 @@ docker_packages: []
 # List of UNIX accounts which should be added to ``docker`` system group which
 # has access to the Docker UNIX socket.
 docker_admins: [ '{{ (ansible_ssh_user
-                      if (ansible_ssh_user | bool and
+                      if (ansible_ssh_user|d() | bool and
                           ansible_ssh_user != "root")
                       else lookup("env", "USER")) }}' ]
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,7 +32,7 @@ docker_upstream_repository: 'deb https://apt.dockerproject.org/repo {{ ansible_d
 # .. envvar:: docker_base_packages
 #
 # List of base packages to install with Docker.
-docker_base_packages: [ 'aufs-tools', 'python-docker' ]
+docker_base_packages: [ 'aufs-tools', 'python-docker', 'python-setuptools' ]
 
 
 # .. envvar:: docker_packages

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,8 +24,8 @@
     install_recommends: False
   with_flattened:
     - '{{ "docker-engine" if docker_upstream|d() else "docker.io" }}'
-    - docker_base_packages
-    - docker_packages
+    - '{{ docker_base_packages }}'
+    - '{{ docker_packages }}'
 
 - name: Install ferment generator
   pip:
@@ -96,7 +96,7 @@
     name: '{{ item }}'
     groups: 'docker'
     append: True
-  with_items: docker_admins
+  with_items: '{{ docker_admins }}'
   when: item|d()
   tags: [ 'role::docker:config', 'role::docker:admins' ]
 


### PR DESCRIPTION
Without it, the task "_Install ferment generator_" fails (tested on Ubuntu 16.04)

Before commit:

```
TASK [debops.docker : Install ferment generator] *******************************
fatal: [nelson.cluster]: FAILED! => {
  "changed": false,
  "cmd": "/usr/local/bin/pip install ferment",
  "failed": true, "msg":
  "stdout: Collecting ferment\n  Using cached Ferment-0.0.1-py2.py3-none-any.whl\nRequirement already satisfied (use --upgrade to upgrade): docker-py in /usr/lib/python2.7/dist-packages (from ferment)\nCollecting wheezy.template (from ferment)\n  Using cached wheezy.template-0.1.167.tar.gz\n\n:stderr: Could not import setuptools which is required to install from a source distribution.\nPlease install setuptools.\n"
}
```

After commit:

```
TASK [debops.docker : Install ferment generator] *******************************
changed: [nelson.cluster] => (item=setuptools)
changed: [nelson.cluster] => (item=ferment)
```
