### PR TITLE
Add internet proxy configuration

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -89,7 +89,6 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  notify: [ 'Restart docker' ]
   register: docker_register_systemd_service
   when: docker_upstream|d() | bool
   tags: [ 'role::docker:config' ]
@@ -101,24 +100,29 @@
     owner: 'root'
     group: 'root'
     mode: '0644'
-  notify: [ 'Restart docker' ]
-  register: docker_register_systemd_service
+  register: docker_register_systemd_proxy_present
   when: (docker_upstream|d() | bool) and 
     (inventory__environment is defined and inventory__environment.http_proxy is defined)
   tags: [ 'role::docker:config' ]
 
 - name: Remove Docker proxy configuration
   file:  path='/etc/systemd/system/docker.service.d/http-proxy.conf' state=absent
+  register: docker_register_systemd_proxy_absent
   when: (docker_upstream|d() | bool) and 
     (inventory__environment is not defined or inventory__environment.http_proxy is not defined)
   tags: [ 'role::docker:config' ]
 
 - name: Reload systemd daemons
   command: systemctl daemon-reload
+  notify: [ 'Restart docker']
   when: ((ansible_local|d() and ansible_local.init|d() and
           ansible_local.init == 'systemd') and
-         docker_register_systemd_service|d() and
-         docker_register_systemd_service.changed)
+         ((docker_register_systemd_service|d() and
+         docker_register_systemd_service.changed) or
+         (docker_register_systemd_proxy_present|d() and
+         docker_register_systemd_proxy_present.changed) or
+         (docker_register_systemd_proxy_absent|d() and
+         docker_register_systemd_proxy_absent.changed)))
   tags: [ 'role::docker:config' ]
 
 - name: Add specified users to 'docker' group

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,6 +71,17 @@
   when: docker_upstream|d() | bool
   tags: [ 'role::docker:config' ]
 
+- name: Make sure that docker.service.d directory exists
+  file:
+    path: '/etc/systemd/system/docker.service.d'
+    state: 'directory'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+  when: (docker_upstream|d() | bool) and 
+      (inventory__environment is defined and inventory__environment.http_proxy is defined)
+  tags: [ 'role::docker:config' ]
+
 - name: Install Debian systemd service unit
   template:
     src: 'etc/systemd/system/docker.service.j2'
@@ -81,6 +92,25 @@
   notify: [ 'Restart docker' ]
   register: docker_register_systemd_service
   when: docker_upstream|d() | bool
+  tags: [ 'role::docker:config' ]
+
+- name: Configure Docker proxy
+  template:
+    src: 'etc/systemd/system/docker.service.d/http-proxy.conf.j2'
+    dest: '/etc/systemd/system/docker.service.d/http-proxy.conf'
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+  notify: [ 'Restart docker' ]
+  register: docker_register_systemd_service
+  when: (docker_upstream|d() | bool) and 
+    (inventory__environment is defined and inventory__environment.http_proxy is defined)
+  tags: [ 'role::docker:config' ]
+
+- name: Remove Docker proxy configuration
+  file:  path='/etc/systemd/system/docker.service.d/http-proxy.conf' state=absent
+  when: (docker_upstream|d() | bool) and 
+    (inventory__environment is not defined or inventory__environment.http_proxy is not defined)
   tags: [ 'role::docker:config' ]
 
 - name: Reload systemd daemons

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -120,9 +120,9 @@
          ((docker_register_systemd_service|d() and
          docker_register_systemd_service.changed) or
          (docker_register_systemd_proxy_present|d() and
-         docker_register_systemd_proxy_present.changed) or
+         docker_register_systemd_proxy_present|changed) or
          (docker_register_systemd_proxy_absent|d() and
-         docker_register_systemd_proxy_absent.changed)))
+         docker_register_systemd_proxy_absent|changed)))
   tags: [ 'role::docker:config' ]
 
 - name: Add specified users to 'docker' group

--- a/templates/etc/systemd/system/docker.service.d/http-proxy.conf.j2
+++ b/templates/etc/systemd/system/docker.service.d/http-proxy.conf.j2
@@ -1,0 +1,6 @@
+# {{ ansible_managed }}
+
+{% if inventory__environment.http_proxy %}
+[Service]
+Environment="HTTP_PROXY={{ inventory__environment.http_proxy }}" {% if inventory__environment.https_proxy %}"HTTPS_PROXY={{ inventory__environment.https_proxy }}"{% endif %} {% if inventory__environment.no_proxy %}"NO_PROXY={{ inventory__environment.no_proxy }}"{% endif %} 
+{% endif %}


### PR DESCRIPTION
Internet proxy needs to be configured in systemd for Docker.
If inventory__environment.http_proxy is set, the proxy is configured in
/etc/systemd/system/docker.service.d/http-proxy.conf.
If inventory__environment.http_proxy is not set, the proxy configuration
is removed if set.
