### PR TITLE
Correct tls port docker daemon

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,10 @@ The current role maintainer is drybjed.
 
 .. _debops.docker master: https://github.com/debops/ansible-docker/compare/v0.2.1...master
 
+Changed
+~~~~~~~
+
+- Docker daemon listens on port 2376 when TLS is used. [tallandtree]
 
 `debops.docker v0.2.1`_ - 2016-08-29
 ------------------------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -129,10 +129,22 @@ docker__tcp: '{{ docker__pki | bool }}'
 docker__tcp_bind: '0.0.0.0'
 
                                                                    # ]]]
+# .. envvar:: docker__unencrypted_tcp_port [[[
+#
+# Port on which to listen for incoming unencrypted connections.
+docker__unencrypted_tcp_port: '2375'
+
+                                                                   # ]]]
+# .. envvar:: docker__tls_tcp_port [[[
+#
+# Port on which to listen for incoming TLS connections.
+docker__tls_tcp_port: '2376'
+
+                                                                   # ]]]
 # .. envvar:: docker__tcp_port [[[
 #
 # Port on which to listen for incoming TLS connections.
-docker__tcp_port: '2375'
+docker__tcp_port: '{{ docker__tls_tcp_port if (docker__pki|d() | bool) else docker__unencrypted_tcp_port }}'
 
                                                                    # ]]]
 # .. envvar:: docker__tcp_allow [[[
@@ -287,6 +299,21 @@ docker__pki_crt: 'default.crt'
 #
 # Name of the private key file used by Docker.
 docker__pki_key: 'default.key'
+
+                                                                   # ]]]
+# .. envvar:: docker__private_registry_keys [[[
+#
+# Dictionary with private registry name and keys for
+# secure client-server communication.
+#
+# .. code-block:: yaml
+#    :linenos:
+#
+#    docker__private_registry_keys:
+#      'myregistry1.domain.com': '/etc/pki/realm/domain/CA.crt'
+#      'myregistry2domain.com:5000': '/etc/pki/realm/domain/CA.crt'
+docker__private_registry_keys: {}
+
                                                                    # ]]]
                                                                    # ]]]
 # Firewall and ferment support [[[
@@ -318,11 +345,11 @@ docker__ferment_wrapper: '{{ (ansible_local.root.lib
 docker__etc_services__dependent_list:
 
   - name: 'docker'
-    port: '2375'
+    port: '{{ docker__unencrypted_tcp_port }}'
     comment: 'Docker REST API (plain text)'
 
   - name: 'docker-s'
-    port: '2376'
+    port: '{{ docker__tls_tcp_port }}'
     comment: 'Docker REST API (SSL)'
 
                                                                    # ]]]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -301,20 +301,6 @@ docker__pki_crt: 'default.crt'
 docker__pki_key: 'default.key'
 
                                                                    # ]]]
-# .. envvar:: docker__private_registry_keys [[[
-#
-# Dictionary with private registry name and keys for
-# secure client-server communication.
-#
-# .. code-block:: yaml
-#    :linenos:
-#
-#    docker__private_registry_keys:
-#      'myregistry1.domain.com': '/etc/pki/realm/domain/CA.crt'
-#      'myregistry2domain.com:5000': '/etc/pki/realm/domain/CA.crt'
-docker__private_registry_keys: {}
-
-                                                                   # ]]]
                                                                    # ]]]
 # Firewall and ferment support [[[
 # --------------------------------

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -23,6 +23,10 @@ firewall rules automatically, however it does not fully support Docker yet, so
 be aware of this when you modify the firewall configuration. You can restart
 ``docker`` daemon to make sure that all firewall rules are set up correctly.
 
+To let the docker daemon trust a private registry with self-signed certificates,
+add the root CA used to sign the registry's certificate through the ``debops.pki``
+role.
+
 ``debops.docker`` relies on configuration managed by ``debops.core``,
 ``debops.ferm``, and ``debops.pki`` Ansible roles.
 


### PR DESCRIPTION
Docker daemon should listen on 2376 by convention for encrypted communication.
