### PR TITLE
Added a ferm hook to restart docker.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,11 @@ The current role maintainer is drybjed.
 
 .. _debops.docker master: https://github.com/debops/ansible-docker/compare/v0.2.1...master
 
+Added
+~~~~~
+- Ferm hook to restart docker daemon after ferm is restarted if :any:`docker__ferment`
+  is set to False. [tallandtree]
+
 Changed
 ~~~~~~~
 

--- a/files/etc/ferm/hooks/post.d/restart-docker
+++ b/files/etc/ferm/hooks/post.d/restart-docker
@@ -1,0 +1,2 @@
+#!/bin/bash
+systemctl restart docker

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,6 +59,15 @@
     mode: '0755'
   when: docker__ferment|d() | bool
 
+- name: Install ferm post hook
+  copy:
+    src: 'etc/ferm/hooks/post.d/restart-docker'
+    dest: '/etc/ferm/hooks/post.d/restart-docker'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+  when: ((ferm__enabled|d() | bool) and (docker__ferment|d() | bool == False))
+
 - name: Check Docker version
   environment:
     LC_MESSAGES: 'C'


### PR DESCRIPTION
Docker iptables rules are not correctly set by ferment wrapper.
Therefore if docker ferment wrapper is disabled, docker daemon
needs to be restarted to reinitialize the docker iptables rules.
