### PR TITLE
Allow overide ferment pip package

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -316,6 +316,7 @@ docker__ferment: True
 #
 # Packages to install ferment from PyPI using the ``pip`` command.
 docker__ferment_pip_package: 'ferment'
+
                                                                    # ]]]
 # .. envvar:: docker__ferment_wrapper [[[
 #

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -312,6 +312,11 @@ docker__pki_key: 'default.key'
 docker__ferment: True
 
                                                                    # ]]]
+# .. envvar:: docker__ferment_pip_package [[[
+#
+# Packages to install ferment from PyPI using the ``pip`` command.
+docker__ferment_pip_package: 'ferment'
+                                                                   # ]]]
 # .. envvar:: docker__ferment_wrapper [[[
 #
 # Path to the :program:`ferment` wrapper script used to generate ``ferm`` configuration.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,7 +46,7 @@
 
 - name: Install ferment generator
   pip:
-    name: 'ferment'
+    name: '{{ docker__ferment_pip_package }}'
     state: 'present'
   when: docker__ferment|d() | bool
 


### PR DESCRIPTION
The project is not getting the care it deserves and it would be interesting to be able to inform another repository to install the ferment.