### PR TITLE
Add docker storage vars for additional daemon.json config.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -239,6 +239,19 @@ docker__graph: '/var/lib/docker'
 docker__registry_mirrors: []
 
                                                                    # ]]]
+
+# .. envvar:: docker__storage_driver [[[
+#
+# Storage driver for docker volumes.
+docker__storage_driver: 'overlay'
+
+                                                                   # ]]]
+# .. envvar:: docker__storage_options [[[
+#
+# Additional docker storage driver options.
+docker__storage_options: []
+
+                                                                   # ]]]
 # .. envvar:: docker__options [[[
 #
 # List of additional options passed to ``docker`` daemon. Examples:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -249,7 +249,7 @@ docker__storage_driver: 'overlay'
 # .. envvar:: docker__storage_options [[[
 #
 # Additional docker storage driver options.
-docker__storage_options: []
+docker__storage_options: {}
 
                                                                    # ]]]
 # .. envvar:: docker__options [[[

--- a/templates/etc/docker/daemon.json.j2
+++ b/templates/etc/docker/daemon.json.j2
@@ -57,4 +57,14 @@
 {%-   endfor %}
 {%    set _ = docker__tpl_options.update({"labels": docker__tpl_labels}) %}
 {%- endif %}
+{%  if docker__storage_driver|d() -%}
+{%    set _ = docker__tpl_options.update({"storage-driver": docker__storage_driver}) %}
+{%- endif %}
+{%  if docker__storage_options|d() -%}
+{%    set docker__tpl_storage_options = [] %}
+{%    for key, value in docker__storage_options.iteritems() -%}
+{%      set _ = docker__tpl_storage_options.append(key+"="+value) %}
+{%-   endfor %}
+{%    set _ = docker__tpl_options.update({"storage-opts": docker__tpl_storage_options}) %}
+{%- endif %}
 {{ docker__tpl_options | to_nice_json }}


### PR DESCRIPTION
This change adds two new vars for configuring storage options in daemon.json.

Example variable configuration:
```
---
docker__storage_driver: devicemapper
docker__storage_options:
  dm.thinpooldev: '/dev/mapper/docker-thinpool'
  dm.use_deferred_removal: 'true'
  dm.use_deferred_deletion: 'true'
```

Example daemon.json output:
```
{
    "dns": [
        "8.8.8.8", 
        "8.8.4.4"
    ], 
    "graph": "/var/lib/docker", 
    "hosts": [
        "fd://", 
        "tcp://0.0.0.0:2376"
    ], 
    "storage-driver": "devicemapper", 
    "storage-opts": [
        "dm.thinpooldev=/dev/mapper/docker-thinpool", 
        "dm.use_deferred_removal=true", 
        "dm.use_deferred_deletion=true"
    ], 
    "tlscacert": "/etc/pki/realms/domain/CA.crt", 
    "tlscert": "/etc/pki/realms/domain/default.crt", 
    "tlskey": "/etc/pki/realms/domain/default.key", 
    "tlsverify": true
}
```

This has been tested as working on Ubuntu 16.04