### PR TITLE
Add var for supporting arbitrary/future daemon.json options.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -252,6 +252,13 @@ docker__storage_driver: 'overlay'
 docker__storage_options: {}
 
                                                                    # ]]]
+# .. envvar:: docker__arb_daemon_opts [[[
+#
+# Allows passing of arbitrary/unsupported configuration options to
+# 'daemon.json'.
+docker__arb_daemon_opts: []
+
+                                                                   # ]]]
 # .. envvar:: docker__options [[[
 #
 # List of additional options passed to ``docker`` daemon. Examples:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -252,11 +252,11 @@ docker__storage_driver: 'overlay'
 docker__storage_options: {}
 
                                                                    # ]]]
-# .. envvar:: docker__arb_daemon_opts [[[
+# .. envvar:: docker__custom_daemon_options [[[
 #
 # Allows passing of arbitrary/unsupported configuration options to
 # 'daemon.json'.
-docker__arb_daemon_opts: {}
+docker__custom_daemon_options: {}
 
                                                                    # ]]]
 # .. envvar:: docker__options [[[

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -256,7 +256,7 @@ docker__storage_options: {}
 #
 # Allows passing of arbitrary/unsupported configuration options to
 # 'daemon.json'.
-docker__arb_daemon_opts: []
+docker__arb_daemon_opts: {}
 
                                                                    # ]]]
 # .. envvar:: docker__options [[[

--- a/templates/etc/docker/daemon.json.j2
+++ b/templates/etc/docker/daemon.json.j2
@@ -68,6 +68,6 @@
 {%    set _ = docker__tpl_options.update({"storage-opts": docker__tpl_storage_options}) %}
 {%- endif %}
 {%  if docker__custom_daemon_options|d() -%}
-{%    set _ = docker__tpl_options.update(docker__custom_daemon_options|from_yaml) %}
+{%    set _ = docker__tpl_options.update(docker__custom_daemon_options) %}
 {%- endif %}
 {{ docker__tpl_options | to_nice_json }}

--- a/templates/etc/docker/daemon.json.j2
+++ b/templates/etc/docker/daemon.json.j2
@@ -67,4 +67,7 @@
 {%-   endfor %}
 {%    set _ = docker__tpl_options.update({"storage-opts": docker__tpl_storage_options}) %}
 {%- endif %}
+{%  if docker__arb_daemon_opts|d() -%}
+{%    set _ = docker__tpl_options.update(docker__arb_daemon_opts|from_yaml) %}
+{%- endif %}
 {{ docker__tpl_options | to_nice_json }}

--- a/templates/etc/docker/daemon.json.j2
+++ b/templates/etc/docker/daemon.json.j2
@@ -67,7 +67,7 @@
 {%-   endfor %}
 {%    set _ = docker__tpl_options.update({"storage-opts": docker__tpl_storage_options}) %}
 {%- endif %}
-{%  if docker__arb_daemon_opts|d() -%}
-{%    set _ = docker__tpl_options.update(docker__arb_daemon_opts|from_yaml) %}
+{%  if docker__custom_daemon_options|d() -%}
+{%    set _ = docker__tpl_options.update(docker__custom_daemon_options|from_yaml) %}
 {%- endif %}
 {{ docker__tpl_options | to_nice_json }}


### PR DESCRIPTION
This adds the ability to add a YAML dictionary of additional options not yet supported by this playbook.

Test case yaml:
```
---
docker__arb_daemon_opts:
  monkey: see
  monkey_do:
    monkey_does:
      - the
      - same
      - as
      - you
```

Resulting `/etc/docker/daemon.json`:
```
{
    "dns": [
        "8.8.8.8", 
        "8.8.4.4"
    ], 
    "graph": "/var/lib/docker", 
    "hosts": [
        "fd://", 
        "tcp://0.0.0.0:2376"
    ], 
    "monkey": "see", 
    "monkey_do": {
        "monkey_does": [
            "the", 
            "same", 
            "as", 
            "you"
        ]
    }, 
    "tlscacert": "/etc/pki/realms/domain/CA.crt", 
    "tlscert": "/etc/pki/realms/domain/default.crt", 
    "tlskey": "/etc/pki/realms/domain/default.key", 
    "tlsverify": true
}

```