### PR TITLE
32 support for latest version of docker ce

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 ---
 
 sudo: True
+dist: trusty
 language: 'python'
 python: '2.7'
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,7 +22,10 @@ Added
 ~~~~~
 - Ferm hook to restart docker daemon after ferm is restarted if :envvar:`docker__ferment`
   is set to False. [tallandtree_]
+
 - Use docker upstream repository by default on stretch installations [cultcom]
+
+- Switch to docker-ce and docker-ee. [tallandtree_]
 
 Changed
 ~~~~~~~

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Added
 ~~~~~
 - Ferm hook to restart docker daemon after ferm is restarted if :envvar:`docker__ferment`
   is set to False. [tallandtree_]
+- Use docker upstream repository by default on stretch installations [cultcom]
 
 Changed
 ~~~~~~~

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -44,7 +44,6 @@ docker__upstream: '{{ True
                           ansible_local.core.distribution_release == "stretch")
                       else False }}'
 
-
                                                                    # ]]]
 # .. envvar:: docker__upstream_edition [[[
 #
@@ -87,33 +86,30 @@ docker__upstream_arch_map:
 # Address of the Docker upstream APT repository.
 docker__upstream_repository: '{{ "deb [arch="
         + docker__upstream_arch_map[ansible_architecture]
-        + "] https://download.docker.com/linux/"
-        + docker__distribution|lower
-        + " "
-        + docker__distribution_release
-        + " "
-        + docker__upstream_channel }}'
+        + "] https://download.docker.com/linux/" + docker__distribution|lower + " "
+        + docker__distribution_release + " " + docker__upstream_channel }}'
 
                                                                    # ]]]
 # .. envvar:: docker__mandatory_packages [[[
 #
 # List of mandatory packages to install with Docker.
-docker__mandatory_packages: [ 'apt-transport-https',
-        'ca-certificates',
-        'curl',
-        'gnupg2',
-        'software-properties-common' ]
+docker__mandatory_packages:
+  - 'apt-transport-https'
+  - 'ca-certificates'
+  - 'curl'
+  - 'gnupg2'
+  - 'software-properties-common'
 
                                                                    # ]]]
 # .. envvar:: docker__base_packages [[[
 #
 # List of base packages to install with Docker.
-docker__base_packages: '{{ [
-        "aufs-tools",
-        "python-pip",
-        "python-setuptools",
-        "bridge-utils" ]
-        + ( [ "cgroup-lite" ] if (ansible_distribution_release in ["trusty"]) else [] )|d(omit) }}'
+docker__base_packages:
+  - "aufs-tools"
+  - "python-pip"
+  - "python-setuptools"
+  - "bridge-utils"
+  - '{{ [ "cgroup-lite" ] if (ansible_distribution_release in ["trusty"]) else [] }}'
 
                                                                    # ]]]
 # .. envvar:: docker__packages [[[

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,28 +41,28 @@ docker__distribution_release: '{{ ansible_local.core.distribution_release
 docker__upstream: False
 
                                                                    # ]]]
-# .. envvar:: docker__variant [[[
+# .. envvar:: docker__edition [[[
 #
-# For upstream repositories the variant to be installed: ce or ee. Note that Docker EE
+# For upstream repositories the edition to be installed: ce or ee. Note that Docker EE
 # is not supported on Debian.
-docker__variant: 'ce'
+docker__upstream_edition: 'ce'
 
                                                                    # ]]]
-# .. envvar:: docker__channel [[[
+# .. envvar:: docker__upstream_channel [[[
 #
 # For upstream repositories choose the stable or edge channel.
-docker__channel: 'stable'
+docker__upstream_channel: 'stable'
 
                                                                    # ]]]
 # .. envvar:: docker__upstream_key [[[
 #
 # APT GPG key id used to sign the upstream Docker packages.
 docker__upstream_key: '{{ "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
-                           if (docker__variant == "ce")
+                           if (docker__upstream_edition == "ce")
                            else "DD911E995A64A202E85907D6BC14F10B6D085F96" }}'
 
                                                                    # ]]]
-# .. envvar:: docker__version [[[
+# .. envvar:: docker__upstream_version [[[
 #
 # The docker version to be installed. Leave empty to install the latest (stable or edge)
 # version, or specify a version. Example:
@@ -70,10 +70,17 @@ docker__upstream_key: '{{ "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
 # .. code-block:: yaml
 #    :linenos:
 #
-#    docker__version: '17.05.0~ce-0~ubuntu-xenial'
+#    docker__upstream_version: '17.05.0~ce-0~ubuntu-xenial'
 #
-docker__version: ''
-docker__packagename: '{{"docker-" + docker__variant + "=" + docker__version if docker__version|d() else "docker-" + docker__variant }}'
+docker__upstream_version: ''
+
+                                                                   # ]]]
+# .. envvar:: docker__upstream_packagename [[[
+#
+# The full docker packagename to be installed.
+docker__upstream_packagename: '{{ "docker-" + docker__upstream_edition + "="
+        + docker__upstream_version if docker__upstream_version|d() else "docker-"
+        + docker__upstream_edition }}'
 
                                                                    # ]]]
 # .. envvar:: docker__upstream_arch_map [[[
@@ -88,26 +95,33 @@ docker__upstream_arch_map:
 # .. envvar:: docker__upstream_repository [[[
 #
 # Address of the Docker upstream APT repository.
-docker__upstream_repository: '{{ "deb [arch="
-        + docker__upstream_arch_map[ansible_architecture]
-        + "] https://download.docker.com/linux/"
+docker__upstream_repository: '{{ "deb https://download.docker.com/linux/"
         + docker__distribution|lower
         + " "
         + docker__distribution_release
         + " "
-        + docker__channel }}'
+        + docker__upstream_channel }}'
 
                                                                    # ]]]
 # .. envvar:: docker__mandatory_packages [[[
 #
 # List of mandatory packages to install with Docker.
-docker__mandatory_packages: [ 'apt-transport-https', 'ca-certificates', 'curl', 'gnupg2', 'software-properties-common' ]
+docker__mandatory_packages: [ 'apt-transport-https',
+        'ca-certificates',
+        'curl',
+        'gnupg2',
+        'software-properties-common' ]
 
                                                                    # ]]]
 # .. envvar:: docker__base_packages [[[
 #
 # List of base packages to install with Docker.
-docker__base_packages: [ 'aufs-tools', 'python-pip', 'python-docker', 'python-setuptools', 'bridge-utils' ]
+docker__base_packages: '{{ [
+        "aufs-tools",
+        "python-pip",
+        "python-setuptools",
+        "bridge-utils" ]
+        + ( [ "cgroup-lite" ] if (ansible_distribution_release in ["trusty"]) else [] )|d(omit) }}'
 
                                                                    # ]]]
 # .. envvar:: docker__packages [[[

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,7 +46,7 @@ docker__upstream: '{{ True
 
 
                                                                    # ]]]
-# .. envvar:: docker__edition [[[
+# .. envvar:: docker__upstream_edition [[[
 #
 # For upstream repositories the edition to be installed: ce or ee. Note that Docker EE
 # is not supported on Debian.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -67,25 +67,10 @@ docker__upstream_key: '{{ "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
                            else "DD911E995A64A202E85907D6BC14F10B6D085F96" }}'
 
                                                                    # ]]]
-# .. envvar:: docker__upstream_version [[[
-#
-# The docker version to be installed. Leave empty to install the latest (stable or edge)
-# version, or specify a version. Example:
-#
-# .. code-block:: yaml
-#    :linenos:
-#
-#    docker__upstream_version: '17.05.0~ce-0~ubuntu-xenial'
-#
-docker__upstream_version: ''
-
-                                                                   # ]]]
 # .. envvar:: docker__upstream_packagename [[[
 #
 # The full docker packagename to be installed.
-docker__upstream_packagename: '{{ "docker-" + docker__upstream_edition + "="
-        + docker__upstream_version if docker__upstream_version|d() else "docker-"
-        + docker__upstream_edition }}'
+docker__upstream_packagename: '{{ "docker-" + docker__upstream_edition }}'
 
                                                                    # ]]]
 # .. envvar:: docker__upstream_arch_map [[[

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,7 +43,8 @@ docker__upstream: False
                                                                    # ]]]
 # .. envvar:: docker__variant [[[
 #
-# For upstream repositories the variant to be installed: ce or ee.
+# For upstream repositories the variant to be installed: ce or ee. Note that Docker EE
+# is not supported on Debian.
 docker__variant: 'ce'
 
                                                                    # ]]]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,19 +59,6 @@ docker__upstream_edition: 'ce'
 docker__upstream_channel: 'stable'
 
                                                                    # ]]]
-# .. envvar:: docker__edition [[[
-#
-# For upstream repositories the edition to be installed: ce or ee. Note that Docker EE
-# is not supported on Debian.
-docker__upstream_edition: 'ce'
-
-                                                                   # ]]]
-# .. envvar:: docker__upstream_channel [[[
-#
-# For upstream repositories choose the stable or edge channel.
-docker__upstream_channel: 'stable'
-
-                                                                   # ]]]
 # .. envvar:: docker__upstream_key [[[
 #
 # APT GPG key id used to sign the upstream Docker packages.
@@ -113,7 +100,9 @@ docker__upstream_arch_map:
 # .. envvar:: docker__upstream_repository [[[
 #
 # Address of the Docker upstream APT repository.
-docker__upstream_repository: '{{ "deb https://download.docker.com/linux/"
+docker__upstream_repository: '{{ "deb [arch="
+        + docker__upstream_arch_map[ansible_architecture]
+        + "] https://download.docker.com/linux/"
         + docker__distribution|lower
         + " "
         + docker__distribution_release

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,16 +41,66 @@ docker__distribution_release: '{{ ansible_local.core.distribution_release
 docker__upstream: False
 
                                                                    # ]]]
+# .. envvar:: docker__variant [[[
+#
+# For upstream repositories the variant to be installed: ce or ee.
+docker__variant: 'ce'
+
+                                                                   # ]]]
+# .. envvar:: docker__channel [[[
+#
+# For upstream repositories choose the stable or edge channel.
+docker__channel: 'stable'
+
+                                                                   # ]]]
 # .. envvar:: docker__upstream_key [[[
 #
 # APT GPG key id used to sign the upstream Docker packages.
-docker__upstream_key: '58118E89F3A912897C070ADBF76221572C52609D'
+docker__upstream_key: '{{ "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
+                           if (docker__variant == "ce")
+                           else "DD911E995A64A202E85907D6BC14F10B6D085F96" }}'
+
+                                                                   # ]]]
+# .. envvar:: docker__version [[[
+#
+# The docker version to be installed. Leave empty to install the latest (stable or edge)
+# version, or specify a version. Example:
+#
+# .. code-block:: yaml
+#    :linenos:
+#
+#    docker__version: '17.05.0~ce-0~ubuntu-xenial'
+#
+docker__version: ''
+docker__packagename: '{{"docker-" + docker__variant + "=" + docker__version if docker__version|d() else "docker-" + docker__variant }}'
+
+                                                                   # ]]]
+# .. envvar:: docker__upstream_arch_map [[[
+#
+# A YAML dictionary that maps the ``ansible_architecture`` variable with its
+# corresponding processor architecture used in the Docker repository URLs.
+docker__upstream_arch_map:
+  'x86_64': 'amd64'
+  'armhf':  'armhf'
 
                                                                    # ]]]
 # .. envvar:: docker__upstream_repository [[[
 #
 # Address of the Docker upstream APT repository.
-docker__upstream_repository: 'deb https://apt.dockerproject.org/repo {{ docker__distribution | lower }}-{{ docker__distribution_release }} main'
+docker__upstream_repository: '{{ "deb [arch="
+        + docker__upstream_arch_map[ansible_architecture]
+        + "] https://download.docker.com/linux/"
+        + docker__distribution|lower
+        + " "
+        + docker__distribution_release
+        + " "
+        + docker__channel }}'
+
+                                                                   # ]]]
+# .. envvar:: docker__mandatory_packages [[[
+#
+# List of mandatory packages to install with Docker.
+docker__mandatory_packages: [ 'apt-transport-https', 'ca-certificates', 'curl', 'gnupg2', 'software-properties-common' ]
 
                                                                    # ]]]
 # .. envvar:: docker__base_packages [[[
@@ -244,7 +294,9 @@ docker__registry_mirrors: []
 # .. envvar:: docker__storage_driver [[[
 #
 # Storage driver for docker volumes.
-docker__storage_driver: 'overlay'
+docker__storage_driver: '{{ "aufs"
+                             if (ansible_distribution_release in ["wheezy", "jessie" ])
+                             else "overlay" }}'
 
                                                                    # ]]]
 # .. envvar:: docker__storage_options [[[

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,28 +46,28 @@ docker__upstream: '{{ True
 
 
                                                                    # ]]]
-# .. envvar:: docker__variant [[[
+# .. envvar:: docker__edition [[[
 #
-# For upstream repositories the variant to be installed: ce or ee. Note that Docker EE
+# For upstream repositories the edition to be installed: ce or ee. Note that Docker EE
 # is not supported on Debian.
-docker__variant: 'ce'
+docker__upstream_edition: 'ce'
 
                                                                    # ]]]
-# .. envvar:: docker__channel [[[
+# .. envvar:: docker__upstream_channel [[[
 #
 # For upstream repositories choose the stable or edge channel.
-docker__channel: 'stable'
+docker__upstream_channel: 'stable'
 
                                                                    # ]]]
 # .. envvar:: docker__upstream_key [[[
 #
 # APT GPG key id used to sign the upstream Docker packages.
 docker__upstream_key: '{{ "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
-                           if (docker__variant == "ce")
+                           if (docker__upstream_edition == "ce")
                            else "DD911E995A64A202E85907D6BC14F10B6D085F96" }}'
 
                                                                    # ]]]
-# .. envvar:: docker__version [[[
+# .. envvar:: docker__upstream_version [[[
 #
 # The docker version to be installed. Leave empty to install the latest (stable or edge)
 # version, or specify a version. Example:
@@ -75,10 +75,17 @@ docker__upstream_key: '{{ "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
 # .. code-block:: yaml
 #    :linenos:
 #
-#    docker__version: '17.05.0~ce-0~ubuntu-xenial'
+#    docker__upstream_version: '17.05.0~ce-0~ubuntu-xenial'
 #
-docker__version: ''
-docker__packagename: '{{"docker-" + docker__variant + "=" + docker__version if docker__version|d() else "docker-" + docker__variant }}'
+docker__upstream_version: ''
+
+                                                                   # ]]]
+# .. envvar:: docker__upstream_packagename [[[
+#
+# The full docker packagename to be installed.
+docker__upstream_packagename: '{{ "docker-" + docker__upstream_edition + "="
+        + docker__upstream_version if docker__upstream_version|d() else "docker-"
+        + docker__upstream_edition }}'
 
                                                                    # ]]]
 # .. envvar:: docker__upstream_arch_map [[[
@@ -93,26 +100,33 @@ docker__upstream_arch_map:
 # .. envvar:: docker__upstream_repository [[[
 #
 # Address of the Docker upstream APT repository.
-docker__upstream_repository: '{{ "deb [arch="
-        + docker__upstream_arch_map[ansible_architecture]
-        + "] https://download.docker.com/linux/"
+docker__upstream_repository: '{{ "deb https://download.docker.com/linux/"
         + docker__distribution|lower
         + " "
         + docker__distribution_release
         + " "
-        + docker__channel }}'
+        + docker__upstream_channel }}'
 
                                                                    # ]]]
 # .. envvar:: docker__mandatory_packages [[[
 #
 # List of mandatory packages to install with Docker.
-docker__mandatory_packages: [ 'apt-transport-https', 'ca-certificates', 'curl', 'gnupg2', 'software-properties-common' ]
+docker__mandatory_packages: [ 'apt-transport-https',
+        'ca-certificates',
+        'curl',
+        'gnupg2',
+        'software-properties-common' ]
 
                                                                    # ]]]
 # .. envvar:: docker__base_packages [[[
 #
 # List of base packages to install with Docker.
-docker__base_packages: [ 'aufs-tools', 'python-pip', 'python-docker', 'python-setuptools', 'bridge-utils' ]
+docker__base_packages: '{{ [
+        "aufs-tools",
+        "python-pip",
+        "python-setuptools",
+        "bridge-utils" ]
+        + ( [ "cgroup-lite" ] if (ansible_distribution_release in ["trusty"]) else [] )|d(omit) }}'
 
                                                                    # ]]]
 # .. envvar:: docker__packages [[[

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,7 +38,12 @@ docker__distribution_release: '{{ ansible_local.core.distribution_release
 # upstream version of Docker.
 # Note that switching from upstream to default on one host, may not always
 # work. You may need to manually remove the upstream version and configuration.
-docker__upstream: False
+docker__upstream: '{{ True
+                      if (ansible_local|d() and ansible_local.core|d() and
+                          ansible_local.core.distribution_release|d() and
+                          ansible_local.core.distribution_release == "stretch")
+                      else False }}'
+
 
                                                                    # ]]]
 # .. envvar:: docker__upstream_key [[[

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,7 +48,8 @@ docker__upstream: '{{ True
                                                                    # ]]]
 # .. envvar:: docker__variant [[[
 #
-# For upstream repositories the variant to be installed: ce or ee.
+# For upstream repositories the variant to be installed: ce or ee. Note that Docker EE
+# is not supported on Debian.
 docker__variant: 'ce'
 
                                                                    # ]]]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -46,16 +46,66 @@ docker__upstream: '{{ True
 
 
                                                                    # ]]]
+# .. envvar:: docker__variant [[[
+#
+# For upstream repositories the variant to be installed: ce or ee.
+docker__variant: 'ce'
+
+                                                                   # ]]]
+# .. envvar:: docker__channel [[[
+#
+# For upstream repositories choose the stable or edge channel.
+docker__channel: 'stable'
+
+                                                                   # ]]]
 # .. envvar:: docker__upstream_key [[[
 #
 # APT GPG key id used to sign the upstream Docker packages.
-docker__upstream_key: '58118E89F3A912897C070ADBF76221572C52609D'
+docker__upstream_key: '{{ "9DC858229FC7DD38854AE2D88D81803C0EBFCD88"
+                           if (docker__variant == "ce")
+                           else "DD911E995A64A202E85907D6BC14F10B6D085F96" }}'
+
+                                                                   # ]]]
+# .. envvar:: docker__version [[[
+#
+# The docker version to be installed. Leave empty to install the latest (stable or edge)
+# version, or specify a version. Example:
+#
+# .. code-block:: yaml
+#    :linenos:
+#
+#    docker__version: '17.05.0~ce-0~ubuntu-xenial'
+#
+docker__version: ''
+docker__packagename: '{{"docker-" + docker__variant + "=" + docker__version if docker__version|d() else "docker-" + docker__variant }}'
+
+                                                                   # ]]]
+# .. envvar:: docker__upstream_arch_map [[[
+#
+# A YAML dictionary that maps the ``ansible_architecture`` variable with its
+# corresponding processor architecture used in the Docker repository URLs.
+docker__upstream_arch_map:
+  'x86_64': 'amd64'
+  'armhf':  'armhf'
 
                                                                    # ]]]
 # .. envvar:: docker__upstream_repository [[[
 #
 # Address of the Docker upstream APT repository.
-docker__upstream_repository: 'deb https://apt.dockerproject.org/repo {{ docker__distribution | lower }}-{{ docker__distribution_release }} main'
+docker__upstream_repository: '{{ "deb [arch="
+        + docker__upstream_arch_map[ansible_architecture]
+        + "] https://download.docker.com/linux/"
+        + docker__distribution|lower
+        + " "
+        + docker__distribution_release
+        + " "
+        + docker__channel }}'
+
+                                                                   # ]]]
+# .. envvar:: docker__mandatory_packages [[[
+#
+# List of mandatory packages to install with Docker.
+docker__mandatory_packages: [ 'apt-transport-https', 'ca-certificates', 'curl', 'gnupg2', 'software-properties-common' ]
 
                                                                    # ]]]
 # .. envvar:: docker__base_packages [[[
@@ -249,7 +299,9 @@ docker__registry_mirrors: []
 # .. envvar:: docker__storage_driver [[[
 #
 # Storage driver for docker volumes.
-docker__storage_driver: 'overlay'
+docker__storage_driver: '{{ "aufs"
+                             if (ansible_distribution_release in ["wheezy", "jessie" ])
+                             else "overlay" }}'
 
                                                                    # ]]]
 # .. envvar:: docker__storage_options [[[

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -32,6 +32,10 @@ To let the docker daemon trust a private registry with self-signed certificates,
 add the root CA used to sign the registry's certificate through the debops.pki_
 role.
 
+This role does not support switching from Docker CE to Docker EE on an already installed
+machine. It does support switching from distribution repository to upstream.
+However, it is recommended to start with a clean machine if possible.
+
 ``debops.docker`` relies on configuration managed by debops.core_,
 debops.ferm_, and debops.pki_ Ansible roles.
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -9,6 +9,9 @@ Getting started
 Initial configuration
 ---------------------
 
+Docker is available in two editions. Community Edition (CE) and Enterprise Edition (EE).
+Docker EE is not supported on Debian distributions. See also: `Docker variants`_.
+
 The Docker package from distribution repositories will be installed by default
 (on Jessie it means that the ``jessie-backports`` repository needs to be available,
 which is the default in DebOps). You can install the upstream version of Docker
@@ -31,6 +34,8 @@ role.
 
 ``debops.docker`` relies on configuration managed by debops.core_,
 debops.ferm_, and debops.pki_ Ansible roles.
+
+.. _Docker variants: https://docs.docker.com/engine/installation/#docker-variants
 
 Useful variables
 ----------------

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,29 @@
     repo: '{{ docker__upstream_repository }}'
     state: 'present'
     update_cache: True
+  register: docker__register_apt_repo
   when: docker__upstream|d() | bool
+
+- name: Make sure that systemd directory exists
+  file:
+    path: '/etc/systemd/system'
+    state: 'directory'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+  when: ansible_service_mgr == 'systemd'
+  tags: [ 'role::docker:config' ]
+
+- name: Make sure that docker.service.d directory exists
+  file:
+    path: '/etc/systemd/system/docker.service.d'
+    state: 'directory'
+    owner: 'root'
+    group: 'root'
+    mode: '0755'
+  when: (ansible_service_mgr == 'systemd' and
+        (docker__env_http_proxy is defined or docker__env_https_proxy is defined))
+  tags: [ 'role::docker:config' ]
 
 - name: Remove other version if upstream is modified
   apt:
@@ -24,16 +46,21 @@
     install_recommends: False
   register: docker__register_other_version_removed
   with_flattened:
-    - '{{ "docker.io docker-engine" if docker__upstream|d()
+    - '{{ "docker.io" if docker__upstream|d()
                 else docker__packagename }}'
 
-- name: Remove custom systemd startup file if present
+- name: Remove startup file(s) if present
   file:
-    path: '/etc/systemd/system/docker.service'
+    path: '{{ item }}'
     state: 'absent'
   tags: [ 'role::docker:config' ]
-  when: (ansible_service_mgr == 'systemd' and
-         docker__register_other_version_removed|changed)
+  with_flattened:
+    - '/etc/systemd/system/docker.service'
+    - '/lib/systemd/system/docker.service'
+    - '/etc/default/docker'
+    - '/etc/docker/daemon.json'
+    - '/etc/systemd/system/docker.service.d/http-proxy.conf'
+  when: (docker__register_other_version_removed|changed)
 
 - name: Install required packages
   apt:
@@ -90,13 +117,6 @@
   tags: [ 'role::docker:config' ]
   when: (ansible_service_mgr != 'systemd' or docker__register_version.stdout | version_compare('1.10', '<'))
 
-- name: Remove Upstart docker configuration file
-  file:
-    path: '/etc/default/docker'
-    state: 'absent'
-  tags: [ 'role::docker:config' ]
-  when: (ansible_service_mgr == 'systemd' and docker__register_version.stdout | version_compare('1.10', '>='))
-
 - name: Configure Docker systemd options
   template:
     src: 'etc/docker/daemon.json.j2'
@@ -108,34 +128,6 @@
   tags: [ 'role::docker:config' ]
   when: (ansible_service_mgr == 'systemd' and docker__register_version.stdout | version_compare('1.10', '>='))
 
-- name: Remove systemd docker configuration file
-  file:
-    path: '/etc/docker/daemon.json'
-    state: 'absent'
-  tags: [ 'role::docker:config' ]
-  when: (ansible_service_mgr != 'systemd' or docker__register_version.stdout | version_compare('1.10', '<'))
-
-- name: Make sure that systemd directory exists
-  file:
-    path: '/etc/systemd/system'
-    state: 'directory'
-    owner: 'root'
-    group: 'root'
-    mode: '0755'
-  when: ansible_service_mgr == 'systemd'
-  tags: [ 'role::docker:config' ]
-
-- name: Make sure that docker.service.d directory exists
-  file:
-    path: '/etc/systemd/system/docker.service.d'
-    state: 'directory'
-    owner: 'root'
-    group: 'root'
-    mode: '0755'
-  when: (ansible_service_mgr == 'systemd' and
-        (docker__env_http_proxy is defined or docker__env_https_proxy is defined))
-  tags: [ 'role::docker:config' ]
-
 - name: Install Debian systemd service unit
   template:
     src: 'etc/systemd/system/docker.service.j2'
@@ -144,6 +136,7 @@
     group: 'root'
     mode: '0644'
   register: docker__register_systemd_service
+  notify: ['Restart docker' ]
   when: ansible_service_mgr == 'systemd'
   tags: [ 'role::docker:config' ]
 
@@ -155,14 +148,8 @@
     group: 'root'
     mode: '0644'
   register: docker__register_systemd_proxy_present
+  notify: ['Restart docker' ]
   when: (ansible_service_mgr == 'systemd' and
-        (docker__env_http_proxy is defined or docker__env_https_proxy is defined))
-  tags: [ 'role::docker:config' ]
-
-- name: Remove Docker proxy configuration
-  file:  path='/etc/systemd/system/docker.service.d/http-proxy.conf' state=absent
-  register: docker__register_systemd_proxy_absent
-  when: (ansible_service_mgr == 'systemd' and not
         (docker__env_http_proxy is defined or docker__env_https_proxy is defined))
   tags: [ 'role::docker:config' ]
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,7 +47,7 @@
   register: docker__register_other_version_removed
   with_flattened:
     - '{{ "docker.io" if docker__upstream|d()
-                else docker__packagename }}'
+                else docker__upstream_packagename }}'
 
 - name: Remove startup file(s) if present
   file:
@@ -69,7 +69,7 @@
     install_recommends: False
   with_flattened:
     - '{{ docker__mandatory_packages }}'
-    - '{{ docker__packagename if docker__upstream|d() else "docker.io" }}'
+    - '{{ docker__upstream_packagename if docker__upstream|d() else "docker.io" }}'
     - '{{ docker__base_packages }}'
     - '{{ docker__packages }}'
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,7 +24,8 @@
     install_recommends: False
   register: docker__register_other_version_removed
   with_flattened:
-    - '{{ "docker.io" if docker__upstream|d() else "docker-engine" }}'
+    - '{{ "docker.io docker-engine" if docker__upstream|d()
+                else docker__packagename }}'
 
 - name: Remove custom systemd startup file if present
   file:
@@ -40,7 +41,8 @@
     state: 'present'
     install_recommends: False
   with_flattened:
-    - '{{ "docker-engine" if docker__upstream|d() else "docker.io" }}'
+    - '{{ docker__mandatory_packages }}'
+    - '{{ docker__packagename if docker__upstream|d() else "docker.io" }}'
     - '{{ docker__base_packages }}'
     - '{{ docker__packages }}'
 
@@ -71,7 +73,7 @@
 - name: Check Docker version
   environment:
     LC_MESSAGES: 'C'
-  shell: dpkg-query -W -f='${Version}\n' '{{ ("docker-engine" if docker__upstream|d() else "docker.io") }}' | cut -d- -f1
+  shell: dpkg-query -W -f='${Version}\n' '{{ ("docker-ce" if docker__upstream|d() else "docker.io") }}' | cut -d- -f1
   register: docker__register_version
   changed_when: False
   failed_when: False

--- a/templates/etc/default/docker.j2
+++ b/templates/etc/default/docker.j2
@@ -6,6 +6,9 @@
 #DOCKER="/usr/local/bin/docker"
 
 {% set docker__tpl_options = [] %}
+{% if docker__graph|d() %}
+{%   set _ = docker__tpl_options.append("--graph " + docker__graph) %}
+{% endif %}
 {% if docker__bridge|d() %}
 {%   set _ = docker__tpl_options.append("--bridge " + docker__bridge) %}
 {% endif %}


### PR DESCRIPTION
The new version supports docker-ce. Also a small inconsistency in the /etc/default/docker is fixed (missing graph option). This options file is only used for older docker versions (<=1.10).