### PR TITLE
set upstream repository as default for stretch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,7 @@ Added
 ~~~~~
 - Ferm hook to restart docker daemon after ferm is restarted if :envvar:`docker__ferment`
   is set to False. [tallandtree_]
+- Use docker upstream repository by default on stretch installations [cultcom]
 
 Changed
 ~~~~~~~

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,7 +38,12 @@ docker__distribution_release: '{{ ansible_local.core.distribution_release
 # upstream version of Docker.
 # Note that switching from upstream to default on one host, may not always
 # work. You may need to manually remove the upstream version and configuration.
-docker__upstream: False
+docker__upstream: '{{ True
+                      if (ansible_local|d() and ansible_local.core|d() and
+                          ansible_local.core.distribution_release|d() and
+                          ansible_local.core.distribution_release == "stretch")
+                      else False }}'
+
 
                                                                    # ]]]
 # .. envvar:: docker__upstream_key [[[


### PR DESCRIPTION
It seems docker.io is currently not availabe for stretch. On jessie it can only be found in the backports repository which is yet not available for stretch.

I suggest to set "docker__upstream" to "true" for stretch right now.