### PR TITLE
package 'virtualenv' does not exit in trusty/wheezy

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -109,7 +109,7 @@ docker__base_packages:
   - "python-pip"
   - "python-setuptools"
   - "python-virtualenv"
-  - "virtualenv"
+  - '{{ [ "virtualenv" ] if (ansible_distribution_release not in ["trusty", "wheezy"]) else [] }}'
   - "bridge-utils"
   - '{{ [ "cgroup-lite" ] if (ansible_distribution_release in ["trusty"]) else [] }}'
 


### PR DESCRIPTION
'virtualenv' comes from Debian jessie and Ubuntu xenial
and python-virtualenv contains virtualenv executables in old releases.
Note that this change covers only LTS releases supported now.

This change fixes following failure in trusy/wheezy targets.

```
TASK [debops.docker : Install required packages] ************************************************************************************************************
failed: [test.example.com] (item=[u'apt-transport-https', u'ca-certificates', u'curl', u'gnupg2', u'software-properties-common', u'docker-ce', u'aufs-tools', u'python-pip', u'python-setuptools', u'python-virtualenv', u'virtualenv', u'bridge-utils', u'cgroup-lite']) => {"failed": true, "item": ["apt-transport-https", "ca-certificates", "curl", "gnupg2", "software-properties-common", "docker-ce", "aufs-tools", "python-pip", "python-setuptools", "python-virtualenv", "virtualenv", "bridge-utils", "cgroup-lite"], "msg": "No package matching 'virtualenv' is available"}
```