### PR TITLE
Updating arch_map with armv7l for use with Raspian/Raspberry

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -77,6 +77,7 @@ docker__upstream_packagename: '{{ "docker-" + docker__upstream_edition }}'
 docker__upstream_arch_map:
   'x86_64': 'amd64'
   'armhf':  'armhf'
+  'armv7l':  'armhf'
 
                                                                    # ]]]
 # .. envvar:: docker__upstream_repository [[[


### PR DESCRIPTION
When running the role on our Raspberry, it first failed. But after making this tiny change, all went fine.
Release = Raspbian GNU/Linux 9 (stretch)
Kernel = Linux 4.14.52-v7+
Platform = Raspberry Pi 3 Model B Rev 1.2
